### PR TITLE
Reduce collisions by using a much larger hash (2^53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,30 @@ Webpack 2 may fix most part of them with [HashedModuleIdsPlugin](https://github.
 Like what HashedModuleIdsPlugin to do, juse one more thing that it converts the hash to num because webpack 1.x just accept num as module id.
 
 OMG!! Forgive my poor English. Just checkout the source code.
+
+### Module ID collisions may cause builds to fail
+
+This plugin calculates a predictable hash values based on the module file 
+names. A hashin algorithm based on MD5 is used to calculate the hash value. 
+As with any hash value, collisions are rare, but possible. In the event of a 
+collision, a `webpack-stable-module-id-and-hash module id collision` error is
+thrown during the Webpack build.
+  
+In such a situation you can try to choose a different `seed` value to get 
+different module IDs that may not collide.
+   
+The probability of a collision depends on the `hashSize` option. By default 
+53 bits are used, which allow 9007199254740992 possible module IDs. This means 
+that the probability of a collision is 0.0000000000000011102% multiplied by 
+the number of modules in your project.
+
+### Options
+
+The plugin acceps an object with these optional properties:
+ 
+- `hashSize` = Number of bits to use for the module ID. Defaults to the 
+maximum, 53 bits. Large hash sizes greatly reduce the probability of a 
+collision but lead also to very large module ID numbers for the generated 
+code, which might *slightly* incrase Webpack chunk sizes.
+- `seed` = Any number between 0 and 31. Different "seed" values cause 
+completely different module IDs. This is useful in the event of a collision. 

--- a/index.js
+++ b/index.js
@@ -21,24 +21,25 @@ function getModSrc(module) {
 }
 
 function hashToModuleId(hash, seed, hashSize) {
-    // Generate a 28 bit integer using a part of the MD5 hash.
-    // Seed is a number 0..31 and the hash is 32 chars (nibbles) long.
+    // Generate a unsigned integer sized <hashSize> bits using a part of the MD5
+    // hash. Seed is a number 0..31 and the hash is expected to be 32 chars
+    // (nibbles) long.
 
     // double the hash to allow overflow
     hash = hash + hash;
 
-    // get lower and upper 32 bits
-    var lsb = parseInt(hash.substr(seed, 8), 16);
-    var msb = parseInt(hash.substr(seed + 8, 8), 16);
+    // get lower and upper 28 bits
+    var lsb = parseInt(hash.substr(seed, 7), 16);
+    var msb = parseInt(hash.substr(seed + 7, 7), 16);
 
     // combine them to get the ID
     // NOTE: Logical operators only work up to 31 bits (because values will be
     // casted to 32bit signed integer), so we use classic arithmetic!
-    var lsbBits = Math.min(31, hashSize);
-    var msbBits = Math.max(0, hashSize - 31);
+    var lsbBits = Math.min(28, hashSize);
+    var msbBits = Math.max(0, hashSize - 28);
     var lsbMask = Math.pow(2, lsbBits) - 1;
     var msbMask = Math.pow(2, msbBits) - 1;
-    return (lsb & lsbMask) + ((msb & msbMask) * Math.pow(2, 31));
+    return (lsb & lsbMask) + ((msb & msbMask) * Math.pow(2, 28));
 }
 
 

--- a/index.js
+++ b/index.js
@@ -20,10 +20,25 @@ function getModSrc(module) {
     return module._source && module._source._value || '';
 }
 
-function hashToModuleId(hash, seed) {
+function hashToModuleId(hash, seed, hashSize) {
     // Generate a 28 bit integer using a part of the MD5 hash.
     // Seed is a number 0..31 and the hash is 32 chars (nibbles) long.
-    return parseInt((hash + hash).substr(seed, 7), 16);
+
+    // double the hash to allow overflow
+    hash = hash + hash;
+
+    // get lower and upper 32 bits
+    var lsb = parseInt(hash.substr(seed, 8), 16);
+    var msb = parseInt(hash.substr(seed + 8, 8), 16);
+
+    // combine them to get the ID
+    // NOTE: Logical operators only work up to 31 bits (because values will be
+    // casted to 32bit signed integer), so we use classic arithmetic!
+    var lsbBits = Math.min(31, hashSize);
+    var msbBits = Math.max(0, hashSize - 31);
+    var lsbMask = Math.pow(2, lsbBits) - 1;
+    var msbMask = Math.pow(2, msbBits) - 1;
+    return (lsb & lsbMask) + ((msb & msbMask) * Math.pow(2, 31));
 }
 
 
@@ -36,11 +51,18 @@ WebpackStableModuleIdAndHash.prototype.apply = function(compiler) {
     var usedIds = {};
     var context = compiler.options.context;
     var seed = (+this.options.seed || 0) % 32;
+    var hashSize = (+this.options.hashSize || 53);
+
+    if (hashSize > 53) {
+        // In JavaScript, only integers up to 2^53 (exclusive) can be considered
+        // safe, see http://www.2ality.com/2013/10/safe-integers.html
+        throw new Error("hashSize too large");
+    }
 
     function genModuleId(modulePath) {
         var hash = md5(modulePath);
         // generatew a 28 bit integer using a part of the MD5 hash
-        var id = hashToModuleId(hash, seed);
+        var id = hashToModuleId(hash, seed, hashSize);
         if (usedIds[id])
           throw new Error("webpack-stable-module-id-and-hash module id collision");
         return id


### PR DESCRIPTION
This PR greatly improves the algorithm by using up to 2^53 module IDs. The number 53 comes from the [JavaScript/EcmaScript limit of the largest integer that can be considered "safe"](http://www.2ality.com/2013/10/safe-integers.html).

The probability of a collision is now 0.0000000000000011102% * (number of modules)!

A new `hashSize` option controls the size of the hash (previous behavior would be 28 bits).

Fortunately Webpack does not store it's modules in an array (it's an object), as otherwise this would lead to immensely huge arrays (and thus memory problems). I actually wonder why module IDs can't be strings.

This version has been successfully tested in current Chrome, Firefox, IE11 and Edge browsers. It should work fine in all browses.

@zhenyong I would be glad if you accept this pull request, thanks!