### PR TITLE
Fixed false collision exception

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ WebpackStableModuleIdAndHash.prototype.apply = function(compiler) {
         var hash = md5(modulePath);
         // generatew a 28 bit integer using a part of the MD5 hash
         var id = hashToModuleId(hash, seed);
-        if (usedIds[id])
+        if (usedIds[id] && usedIds[id] !== modulePath)
           throw new Error("webpack-stable-module-id-and-hash module id collision");
         return id
     }
@@ -60,7 +60,7 @@ WebpackStableModuleIdAndHash.prototype.apply = function(compiler) {
                         context: context
                     });
                     module.id = genModuleId(modulePath);
-                    usedIds[module.id] = true;
+                    usedIds[module.id] = modulePath;
                 }
             });
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-stable-module-id-and-hash",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "To provide stable module id and reliable content chunkhash",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
for some reason webpack may call plugin several times for the same module - this is not collision

I propose to cache `modulePath` and skip exception if the same module appeared again.